### PR TITLE
Use correct name for specialisation

### DIFF
--- a/components/Events.vue
+++ b/components/Events.vue
@@ -48,7 +48,7 @@ export default {
         hex: 'A2E172'
       },
       {
-        courseTitle: 'SNE',
+        courseTitle: 'CSC',
         hex: 'E1DB72'
       },
       {


### PR DESCRIPTION
System & Network Engineering has been renamed to Cyber Security & Cloud.