### PR TITLE
Feature/dynamic header

### DIFF
--- a/components/Nav.vue
+++ b/components/Nav.vue
@@ -136,27 +136,44 @@ export default {
   .logo {
     img {
       max-width: 204px;
+      padding-left: 10px;
+      padding-right: 10px;
     }
   }
 
+  .container.flex{
+    padding: 0px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
   ul {
-    list-style: none;
+    //list-style: none;
     display: flex;
-    max-width: 984px;
+    // max-width: 984px;
     // margin: 0 auto;
     justify-content: space-between;
     align-items: center;
     overflow: auto;
 
     li {
+      width: 500px;
+      padding-top: 15px;
+      padding-bottom: 15px;
       a {
+        position: relative;
         display: block;
-        padding: 24px;
         font-size: 1rem;
         font-weight: 500;
         color: var(--text-color);
         text-align: center;
         text-decoration: none;
+      }
+
+      a:hover{
+        text-decoration: underline;
       }
     }
   }
@@ -166,8 +183,9 @@ export default {
     display: none;
   }
 
+
   // mobile nav
-  @media screen and (max-width: $bp-tablet-sm) {
+  @media screen and (max-width: $bp-tablet-md) {
     opacity: 1;
     position: fixed;
     top: 0;

--- a/components/Nav.vue
+++ b/components/Nav.vue
@@ -85,7 +85,7 @@ export default {
   },
   data: () => ({
     logoUrl: "/logo/indicium-logo-left.svg",
-    isNavShown: true,
+    isNavShown: false,
     items: [
       {
         title: "Partners",
@@ -96,7 +96,7 @@ export default {
         url: "/activiteiten",
       },
       {
-        title: Math.random() > 0.6 ? "Over Indicium" : "Commissies",
+        title: "Over Indicium / Commissies",
         url: "/over-indicium",
       },
       {
@@ -171,7 +171,7 @@ export default {
     opacity: 1;
     position: fixed;
     top: 0;
-    left: 0;
+    left: -100%;
     height: 100%;
     width: 100%;
     background: var(--root-background-color);
@@ -181,10 +181,8 @@ export default {
     align-items: center;
     transition: 100ms linear;
 
-    transform: translateX(-100%);
-
     &.open {
-      transform: translateX(00%);
+      transform: translateX(100%);
     }
 
     ul {

--- a/components/NavToggle.vue
+++ b/components/NavToggle.vue
@@ -67,7 +67,7 @@ export default {
     max-width: 60%;
     display: none;
 
-    @media screen and (max-width: $bp-tablet-sm) {
+    @media screen and (max-width: $bp-tablet-md) {
       display: block;
     }
   }
@@ -81,7 +81,7 @@ export default {
     top: 24px;
     right: 24px;
 
-    @media screen and (max-width: $bp-tablet-sm) {
+    @media screen and (max-width: $bp-tablet-md) {
       display: block;
     }
   }


### PR DESCRIPTION
Fixes the menu popup on old browsers by defaulting it to be offscreen. instead of hiding it directly.

Fixes the header to be more evenly spread,
![image](https://user-images.githubusercontent.com/22635990/112224804-1e50e600-8c2c-11eb-9561-24f05eadabf0.png)
